### PR TITLE
Optional bot dispatch

### DIFF
--- a/.github/workflows/github-integration-test.yml
+++ b/.github/workflows/github-integration-test.yml
@@ -7,14 +7,15 @@ on:
     inputs:
       workflowName:
         description: 'Workflow run name (format: functionappidentifier-instanceId)'
-        required: true
+        required: false
+        default: ''
         type: string
       localVerification:
         description: 'Optional local-only queue publication override JSON supplied by the local Functions dispatcher'
         required: false
         type: string
 
-run-name: ${{ inputs.workflowName }}
+run-name: ${{ inputs.workflowName != '' && inputs.workflowName || format('manual: {0}', github.actor) }}
 
 permissions:
   contents: read
@@ -22,6 +23,7 @@ permissions:
 jobs:
   github-app-authz:
     runs-on: ubuntu-latest
+    if: endsWith(github.triggering_actor, '[bot]')
     permissions:
       contents: read
     outputs:
@@ -70,7 +72,13 @@ jobs:
   dev-task:
     runs-on: ubuntu-latest
     needs: publish-inprogress
-    if: contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'dev')
+    if: |
+      always() && !cancelled() &&
+      (
+        !endsWith(github.triggering_actor, '[bot]') ||
+        (needs.publish-inprogress.result == 'success' &&
+         contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'dev'))
+      )
     environment:
       name: dev
     steps:
@@ -80,7 +88,13 @@ jobs:
   qa-auto-approve:
     runs-on: ubuntu-latest
     needs: publish-inprogress
-    if: contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa')
+    if: |
+      always() && !cancelled() &&
+      (
+        !endsWith(github.triggering_actor, '[bot]') ||
+        (needs.publish-inprogress.result == 'success' &&
+         contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa'))
+      )
     steps:
       - name: Wait for deployment to be registered
         run: sleep 20
@@ -95,7 +109,13 @@ jobs:
   qa-task:
     runs-on: ubuntu-latest
     needs: publish-inprogress
-    if: contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa')
+    if: |
+      always() && !cancelled() &&
+      (
+        !endsWith(github.triggering_actor, '[bot]') ||
+        (needs.publish-inprogress.result == 'success' &&
+         contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa'))
+      )
     environment:
       name: qa
     steps:

--- a/.github/workflows/github-integration-test.yml
+++ b/.github/workflows/github-integration-test.yml
@@ -1,6 +1,82 @@
 name: Orchestrator Test Workflow
 
 # Showcase workflow for queue-callback validation during the migration.
+#
+# =============================================================================
+# DISPATCH SCENARIOS
+# =============================================================================
+#
+# This workflow supports two dispatch modes, detected via github.triggering_actor:
+#   - Bot dispatch:   triggering_actor ends with '[bot]'  (e.g. a GitHub App)
+#   - Human dispatch: triggering_actor does NOT end with '[bot]'
+#
+# -----------------------------------------------------------------------------
+# Scenario 1 — Bot dispatch, GitHub App authorized for BOTH dev AND qa
+# -----------------------------------------------------------------------------
+# Trigger:  Functions app (or other GitHub App) calls workflow_dispatch,
+#           passing workflowName = "InternalApi-<instanceId>"
+#
+# run-name: InternalApi-<instanceId>
+#
+# Job outcomes:
+#   github-app-authz    SUCCESS  — resolves primary env and authorized-target-envs
+#   publish-inprogress  SUCCESS  — publishes GithubWorkflowInProgress to default-queue
+#   dev-task            SUCCESS  — runs in the dev environment
+#   qa-auto-approve     SUCCESS  — auto-approves the qa environment gate
+#   qa-task             SUCCESS  — runs in the qa environment (gate pre-approved above)
+#   publish-completed   SUCCESS  — publishes GithubWorkflowCompleted to default-queue
+#
+# Observable acceptance criteria:
+#   1. run-name equals the supplied workflowName value
+#   2. GithubWorkflowInProgress message arrives in default-queue
+#   3. GithubWorkflowCompleted message arrives in default-queue
+#   4. Durable orchestration for the instanceId reaches a terminal Completed state
+#
+# -----------------------------------------------------------------------------
+# Scenario 2 — Bot dispatch, GitHub App authorized for dev ONLY (not qa)
+# -----------------------------------------------------------------------------
+# Same trigger as Scenario 1, but this App's pipeline does not include qa.
+#
+# run-name: InternalApi-<instanceId>
+#
+# Job outcomes:
+#   github-app-authz    SUCCESS  — authorized-target-envs contains only 'dev'
+#   publish-inprogress  SUCCESS  — publishes GithubWorkflowInProgress
+#   dev-task            SUCCESS  — 'dev' is in authorized-target-envs
+#   qa-auto-approve     SKIPPED  — 'qa' is NOT in authorized-target-envs
+#   qa-task             SKIPPED  — 'qa' is NOT in authorized-target-envs
+#   publish-completed   SUCCESS  — publishes GithubWorkflowCompleted
+#
+# Observable acceptance criteria:
+#   Same as Scenario 1 except no qa environment jobs run and
+#   GithubWorkflowCompleted still arrives (orchestration still succeeds).
+#
+# -----------------------------------------------------------------------------
+# Scenario 3 — Human dispatch (manual trigger from GitHub UI or gh CLI)
+# -----------------------------------------------------------------------------
+# Trigger:  A human runs the workflow manually; workflowName is left blank.
+#
+# run-name: manual: <github.actor>
+#
+# Job outcomes:
+#   github-app-authz    SKIPPED  — bot-only guard; human actors never end with '[bot]'
+#   publish-inprogress  SKIPPED  — depends on github-app-authz with no always(); skipped by dependency
+#   dev-task            SUCCESS  — always() + !cancelled() + !endsWith([bot]) = true
+#   qa-auto-approve     SKIPPED  — bot-only; human dispatch must go through the GitHub environment gate
+#   qa-task             WAITING  — always() + !cancelled() + !endsWith([bot]) = true, but the
+#                                  qa environment has a protection rule requiring human approval;
+#                                  a reviewer must approve before qa-task runs
+#   publish-completed   SKIPPED  — published-in-progress output is empty (publish-inprogress was skipped)
+#
+# Observable acceptance criteria:
+#   1. run-name matches "manual: <actor>"
+#   2. No queue messages are published (no GithubWorkflowInProgress or GithubWorkflowCompleted)
+#   3. No Durable orchestration instance is created for this run
+#   4. dev-task completes successfully without any queue interaction
+#   5. qa-task is blocked at the GitHub environment gate until a reviewer approves
+#   6. After a reviewer approves, qa-task runs successfully
+#
+# =============================================================================
 
 on:
   workflow_dispatch:
@@ -15,12 +91,14 @@ on:
         required: false
         type: string
 
-run-name: ${{ inputs.workflowName != '' && inputs.workflowName || format('manual: {0}', github.actor) }}
+run-name: "${{ inputs.workflowName != '' && inputs.workflowName || format('manual: {0}', github.actor) }}"
 
 permissions:
   contents: read
 
 jobs:
+  # Bot dispatch:    runs — resolves authorized environments for the dispatching GitHub App
+  # Human dispatch:  skipped
   github-app-authz:
     runs-on: ubuntu-latest
     if: endsWith(github.triggering_actor, '[bot]')
@@ -40,6 +118,8 @@ jobs:
             dev
             qa
 
+  # Bot dispatch:    runs — publishes GithubWorkflowInProgress queue message
+  # Human dispatch:  skipped (github-app-authz was skipped, so this is skipped by dependency)
   publish-inprogress:
     runs-on: ubuntu-latest
     needs: github-app-authz
@@ -69,6 +149,8 @@ jobs:
           run-id: ${{ github.run_id }}
           workflow-name: ${{ inputs.workflowName }}
 
+  # Bot dispatch:    runs if 'dev' is in authorized-target-envs; skipped otherwise
+  # Human dispatch:  always runs
   dev-task:
     runs-on: ubuntu-latest
     needs: publish-inprogress
@@ -85,16 +167,15 @@ jobs:
       - uses: actions/checkout@v4
       - run: echo "Building workflow for ${{ inputs.workflowName }} in DEV environment"
 
+  # Bot dispatch:    runs if 'qa' is in authorized-target-envs — auto-approves the qa environment gate
+  # Human dispatch:  skipped — the GitHub environment protection gate requires a human to approve qa-task
   qa-auto-approve:
     runs-on: ubuntu-latest
     needs: publish-inprogress
     if: |
-      always() && !cancelled() &&
-      (
-        !endsWith(github.triggering_actor, '[bot]') ||
-        (needs.publish-inprogress.result == 'success' &&
-         contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa'))
-      )
+      endsWith(github.triggering_actor, '[bot]') &&
+      needs.publish-inprogress.result == 'success' &&
+      contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa')
     steps:
       - name: Wait for deployment to be registered
         run: sleep 20
@@ -106,6 +187,8 @@ jobs:
           environment_allow_list: qa
           run_id_allow_list: ${{ github.run_id }}
 
+  # Bot dispatch:    runs if 'qa' is in authorized-target-envs; skipped otherwise
+  # Human dispatch:  always runs, but waits at the GitHub environment protection gate for a human to approve
   qa-task:
     runs-on: ubuntu-latest
     needs: publish-inprogress
@@ -122,6 +205,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: echo "Building workflow for ${{ inputs.workflowName }} in QA environment"
 
+  # Bot dispatch:    runs — publishes GithubWorkflowCompleted queue message
+  # Human dispatch:  skipped (published-in-progress output is empty when publish-inprogress was skipped)
   publish-completed:
     runs-on: ubuntu-latest
     needs:

--- a/docs/plan-human-bot-dual-dispatch.md
+++ b/docs/plan-human-bot-dual-dispatch.md
@@ -245,28 +245,41 @@ Prerequisites: Azurite running, dev tunnel active, Functions app running locally
 
 **File**: `docs/workflow-orchestration-setup.md`
 
+### Scope boundary — what NOT to do
+
+> **Agent instruction**: Before writing a single word, read this boundary carefully. The two failure modes to avoid are:
+>
+> 1. **Over-complicating the existing minimal example** — the `github-integration-test.yml` workflow is a complex dual-dispatch example. The "Workflow Requirements" minimal example in the doc must remain bot-only and simple. Do **not** add dual-dispatch `if` conditions to it.
+> 2. **Failing to acknowledge the example** — the doc must make it clear that `github-integration-test.yml` IS the canonical reference for dual-dispatch patterns, so readers know it exists without having to reproduce its complexity in prose.
+>
+> The right line to tread: explain the **concept and detection mechanism** concisely, show short **pattern snippets** only (not a full workflow template), and point to `github-integration-test.yml` for the complete implementation. The inline comments within that file are self-documenting — the doc should guide readers there rather than duplicate that information.
+
 ### Steps
 
-- [ ] Re-read `workflow-orchestration-setup.md` to identify the best insertion point (likely after "Workflow Requirements" section, before or within "Authorization Contract").
-- [ ] Add a new section **"Supporting Both Human and Bot Dispatch"** that covers:
-  - The problem statement: authz + queue publishing must be skipped for human dispatch.
-  - The detection pattern: `endsWith(github.triggering_actor, '[bot]')` signals bot dispatch. Explain why input-based detection (`workflowName != ''`) is insecure — a bot controls its own inputs.
-  - A table or list of which jobs are bot-only vs universal.
-  - The job-level `if` condition templates (both the guard pattern for bot-only jobs and the dual-condition pattern for environment jobs).
-  - Reference `github-integration-test.yml` as the canonical implementation example.
-  - Note that shared actions `github-app-authz-envs` and `publish-github-workflow-event` are NOT modified.
-- [ ] Add a new sub-section within "Exact Local E2E Validation Procedure" (or as a sibling section) titled **"Human Dispatch Simulation"** that covers:
-  - Purpose: validate that authz and queue-publishing jobs are skipped and environment jobs still run.
-  - No tunnel, no Azurite, no Functions app required.
-  - Terminal commands (PowerShell): `gh workflow run github-integration-test.yml --ref <branch>` (no `workflowName` input).
-  - How to locate and watch the run: `gh run list --workflow github-integration-test.yml --branch <branch> --limit 5 --json databaseId,displayTitle,status,conclusion | ConvertFrom-Json`.
-  - Pass criteria: `github-app-authz` → skipped, `publish-inprogress` → skipped, `dev-task` → success, `qa-auto-approve` → skipped, `qa-task` → success (after human approval of the qa environment gate), `publish-completed` → skipped.
+- [ ] Re-read `workflow-orchestration-setup.md` to confirm the position of "Workflow Requirements" and "Authorization Contract" sections and identify the correct insertion point for the new section.
+- [ ] Add a new section **"Supporting Both Human and Bot Dispatch"** between "Workflow Requirements" and "Authorization Contract". The section must cover:
+  - **Problem statement**: by default the authz and queue-publishing jobs are bot-only; a workflow that needs to support human dispatch must explicitly detect the dispatch mode.
+  - **Detection pattern**: `endsWith(github.triggering_actor, '[bot]')` is the secure signal — GitHub sets `triggering_actor`, so it cannot be forged via inputs. Briefly explain why using `workflowName != ''` would be insecure.
+  - **Two short pattern snippets only** (not a full workflow template):
+    1. Bot-only guard (for `github-app-authz` and other skippable-by-humans jobs): `if: endsWith(github.triggering_actor, '[bot]')`
+    2. Dual-condition pattern (for environment jobs that must run for both modes): the `always() && !cancelled() && (!endsWith([bot]) || bot-condition)` template.
+  - **Reference to `github-integration-test.yml`** as the canonical full implementation, with a sentence noting that the workflow's inline comments document each job's behaviour for each dispatch scenario.
+  - **Note that `workflowName` becomes optional** when supporting human dispatch, and that `run-name` should handle the empty case (e.g. `format('manual: {0}', github.actor)`). Add the YAML quoting requirement: the `run-name` value **must be double-quoted** when the expression contains `': '` (colon-space), otherwise YAML interprets it as a mapping separator.
+  - **Note that shared actions are NOT modified**: `github-app-authz-envs` and `publish-github-workflow-event` work unchanged for both dispatch modes.
+- [ ] Add a new sibling section **"Human Dispatch Simulation"** immediately after the "Exact Local E2E Validation Procedure" section. This section is specifically about verifying `github-integration-test.yml` and must make that scope explicit. It covers:
+  - **Purpose**: verify that, for a human-triggered run of `github-integration-test.yml`, bot-only jobs are skipped and environment jobs still run without queue interaction.
+  - **No infrastructure required**: no tunnel, no Azurite, no Functions app.
+  - **Terminal commands**: push branch, dispatch via `gh workflow run github-integration-test.yml --ref <branch>` (no inputs), locate run, poll for completion, approve the `qa` environment gate.
+  - **Pass criteria** (framed as specific to `github-integration-test.yml`, not as a general contract): `github-app-authz`=skipped, `publish-inprogress`=skipped, `dev-task`=success, `qa-auto-approve`=skipped, `qa-task`=success (after human approval), `publish-completed`=skipped; run-name = `manual: <actor>`; no Durable instance created.
+  - **Approval step**: include the `gh api .../pending_deployments` POST command with `state=approved` to unblock `qa-task`, since the qa environment gate requires a reviewer.
 - [ ] **Code review checklist**:
-  - [ ] Does the new guidance reference the correct job names and output names?
-  - [ ] Are the `if` condition templates accurate as written (consistent with what was implemented in Phase 1)?
-  - [ ] Is the human dispatch simulation procedure self-contained?
-  - [ ] Are there no references to webhook or HMAC that might now be outdated?
-- [ ] **Consistency check**: Confirm the `if` condition templates written in the doc match exactly what was implemented in Phase 1 and verified in Phase 2. Confirm the human dispatch simulation commands match what was executed in Phase 2 Sub-phase B.
+  - [ ] Does the "Supporting Both Human and Bot Dispatch" section stay at the concept+snippet level, with no full workflow template embedded?
+  - [ ] Does the existing "Workflow Requirements" minimal example remain unchanged (bot-only, simple `workflowName` required)?
+  - [ ] Does `github-integration-test.yml` appear as a named reference, not as an inline duplication?
+  - [ ] Do the pattern snippets match exactly what is implemented in Phase 1?
+  - [ ] Is the "Human Dispatch Simulation" section clearly scoped to `github-integration-test.yml` and not presented as a generic procedure?
+  - [ ] Is the human dispatch simulation procedure self-contained (no cross-references to the bot E2E steps for infrastructure)?
+- [ ] **Consistency check**: Confirm pattern snippets match exactly the `if` conditions in `github-integration-test.yml`. Confirm simulation commands match what was executed in Phase 2 Sub-phase B (Scenario 3 re-run).
 
 ---
 

--- a/docs/plan-human-bot-dual-dispatch.md
+++ b/docs/plan-human-bot-dual-dispatch.md
@@ -101,11 +101,11 @@ Prerequisites: dev tunnel running, Azurite running, Functions app running locall
   > **Feed-forward note**: `github-app-authz` ran (success), `publish-inprogress` ran (success), `publish-completed` ran (success), `dev-task` ran (success). `qa-auto-approve` and `qa-task` were correctly **skipped** because this GitHub App is only authorized for `dev` (not `qa`) — this is the expected, correct behaviour. Also found and fixed a YAML bug: the original `run-name` expression was an unquoted YAML plain scalar containing `': '` (colon-space) from `format('manual: {0}', ...)`, which YAML parsers treat as a mapping separator. Fixed by wrapping the `run-name` value in double quotes.
 
 **Scenario 2 re-run** (after qa-auto-approve redesigned as bot-only):
-- [ ] Verify infrastructure: Azurite running, dev tunnel active, Functions healthy at `GET http://localhost:7071/api/Echo`.
-- [ ] Run bot dispatch E2E per the 12-step procedure above and wait for run to complete.
-- [ ] Verify run conclusion = `success`.
-- [ ] Verify per-job results: `github-app-authz`=success, `publish-inprogress`=success, `dev-task`=success, `qa-auto-approve`=**skipped** (qa not in authorized-target-envs), `qa-task`=**skipped** (qa not in authorized-target-envs), `publish-completed`=success.
-- [ ] Verify Durable terminal state: RuntimeStatus=`Completed`.
+- [x] Verify infrastructure: Azurite running, dev tunnel active, Functions healthy at `GET http://localhost:7071/api/Echo`.
+- [x] Run bot dispatch E2E per the 12-step procedure above and wait for run to complete.
+- [x] Verify run conclusion = `success`.
+- [x] Verify per-job results: `github-app-authz`=success, `publish-inprogress`=success, `dev-task`=success, `qa-auto-approve`=**skipped** (qa not in authorized-target-envs), `qa-task`=**skipped** (qa not in authorized-target-envs), `publish-completed`=success.
+- [x] Verify Durable terminal state: RuntimeStatus=`Completed`.
 
 ### Sub-phase B: Scenario 3 — Human dispatch
 
@@ -166,28 +166,28 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
 
 **Scenario 3 re-run** (confirming qa-auto-approve is now **skipped** for human dispatch):
 
-- [ ] Push current branch: `git push`
-- [ ] Dispatch the workflow as a human (no `workflowName` input):
+- [x] Push current branch: `git push`
+- [x] Dispatch the workflow as a human (no `workflowName` input):
   ```pwsh
   $WorkflowBranch = (git rev-parse --abbrev-ref HEAD).Trim()
   $env:GH_PAGER = 'cat'
   gh workflow run github-integration-test.yml --ref $WorkflowBranch
   ```
-- [ ] Wait ~15 seconds then locate the latest run:
+- [x] Wait ~15 seconds then locate the latest run:
   ```pwsh
   $HumanRuns = gh run list --workflow github-integration-test.yml --branch $WorkflowBranch --limit 5 --json databaseId,displayTitle,status,conclusion,createdAt | ConvertFrom-Json
   $LatestRun = $HumanRuns | Sort-Object createdAt -Descending | Select-Object -First 1
   $LatestRun | Select-Object databaseId, displayTitle, status, conclusion | Format-List
   ```
-- [ ] Confirm run-name = `manual: <actor>`.
-- [ ] Wait for `dev-task` to complete, then approve the `qa` environment gate so `qa-task` can proceed:
+- [x] Confirm run-name = `manual: <actor>`.
+- [x] Wait for `dev-task` to complete, then approve the `qa` environment gate so `qa-task` can proceed:
   ```pwsh
   $QaEnvId = (gh api "repos/christianacca/web-api-starter/environments" | ConvertFrom-Json).environments |
       Where-Object { $_.name -eq 'qa' } | Select-Object -ExpandProperty id
   gh api "repos/christianacca/web-api-starter/actions/runs/$($LatestRun.databaseId)/pending_deployments" `
       --method POST -F "environment_ids[]=$QaEnvId" -f state=approved -f comment="Scenario 3 re-run verification"
   ```
-- [ ] Wait for run to complete and verify per-job results:
+- [x] Wait for run to complete and verify per-job results:
   ```pwsh
   gh run view $LatestRun.databaseId --json jobs | ConvertFrom-Json |
       Select-Object -ExpandProperty jobs | Select-Object name, status, conclusion | Format-Table
@@ -199,7 +199,7 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
   - `qa-auto-approve` → **`skipped`** (bot-only; no auto-approve for human dispatch)
   - `qa-task` → `success` (after approval above)
   - `publish-completed` → `skipped`
-- [ ] Confirm no Durable instance created for this run.
+- [x] Confirm no Durable instance created for this run.
 
 ### Sub-phase C: Scenario 1 — Bot dispatch, GitHub App authorized for dev AND qa
 
@@ -207,16 +207,16 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
 
 Prerequisites: Azurite running, dev tunnel active, Functions app running locally. If infra has been stopped, restart it before proceeding.
 
-- [ ] Modify `get-product-github-app-config.ps1` line 13: change `Pipeline = @('dev')` to `Pipeline = @('dev', 'qa')`.
-- [ ] Commit and push the temporary change:
+- [x] Modify `get-product-github-app-config.ps1` line 13: change `Pipeline = @('dev')` to `Pipeline = @('dev', 'qa')`.
+- [x] Commit and push the temporary change:
   ```pwsh
   git add tools/infrastructure/get-product-github-app-config.ps1
   git commit -m "temp: authorize GitHub App for qa (Scenario 1 E2E — revert before merge)"
   git push
   ```
-- [ ] Run bot dispatch E2E per the 12-step procedure in Sub-phase A. Wait for the run to complete.
-- [ ] Verify run conclusion = `success`.
-- [ ] Verify per-job results:
+- [x] Run bot dispatch E2E per the 12-step procedure in Sub-phase A. Wait for the run to complete.
+- [x] Verify run conclusion = `success`.
+- [x] Verify per-job results:
   ```pwsh
   gh run view $RunId --json jobs | ConvertFrom-Json |
       Select-Object -ExpandProperty jobs | Select-Object name, status, conclusion | Format-Table
@@ -228,14 +228,14 @@ Prerequisites: Azurite running, dev tunnel active, Functions app running locally
   - `qa-auto-approve` → `success` (bot dispatch + qa in authorized-target-envs)
   - `qa-task` → `success` (gate auto-approved by qa-auto-approve above)
   - `publish-completed` → `success`
-- [ ] Verify Durable terminal state: RuntimeStatus = `Completed`.
-- [ ] Verify Functions log contains both `GithubWorkflowInProgress` and `GithubWorkflowCompleted` for the instance.
-- [ ] **Revert** `get-product-github-app-config.ps1` to `Pipeline = @('dev')`:
+- [x] Verify Durable terminal state: RuntimeStatus = `Completed`.
+- [x] Verify Functions log contains both `GithubWorkflowInProgress` and `GithubWorkflowCompleted` for the instance.
+- [x] **Revert** `get-product-github-app-config.ps1` to `Pipeline = @('dev')`:
   ```pwsh
   git revert HEAD --no-edit
   git push
   ```
-- [ ] Confirm `get-product-github-app-config.ps1` line 13 = `Pipeline = @('dev')`.
+- [x] Confirm `get-product-github-app-config.ps1` line 13 = `Pipeline = @('dev')`.
 
 ---
 

--- a/docs/plan-human-bot-dual-dispatch.md
+++ b/docs/plan-human-bot-dual-dispatch.md
@@ -20,16 +20,18 @@ Make `workflowName` input optional. Its presence signals bot dispatch; its absen
 
 ## Phase 1: Modify `github-integration-test.yml`
 
+> **Agent instruction**: tick each checkbox in this document (`- [ ]` → `- [x]`) immediately after completing each step. Do not batch ticks at the end.
+
 **File**: `.github/workflows/github-integration-test.yml`
 
 ### Steps
 
-- [ ] Read `github-integration-test.yml` to confirm current full content before editing.
-- [ ] Make `workflowName` input optional: remove `required: true`, add `default: ''`.
-- [ ] Update `run-name`: `${{ inputs.workflowName != '' && inputs.workflowName || format('manual: {0}', github.actor) }}`.
-- [ ] Add `if: endsWith(github.triggering_actor, '[bot]')` to the `github-app-authz` job. No other change to that job.
-- [ ] Confirm `publish-inprogress` naturally skips (it has `needs: github-app-authz` with no `always()`, so it is skipped when authz is skipped). No change needed.
-- [ ] Update `dev-task` `if` condition:
+- [x] Read `github-integration-test.yml` to confirm current full content before editing.
+- [x] Make `workflowName` input optional: remove `required: true`, add `default: ''`.
+- [x] Update `run-name`: `${{ inputs.workflowName != '' && inputs.workflowName || format('manual: {0}', github.actor) }}`.
+- [x] Add `if: endsWith(github.triggering_actor, '[bot]')` to the `github-app-authz` job. No other change to that job.
+- [x] Confirm `publish-inprogress` naturally skips (it has `needs: github-app-authz` with no `always()`, so it is skipped when authz is skipped). No change needed.
+- [x] Update `dev-task` `if` condition:
   ```yaml
   if: |
     always() && !cancelled() &&
@@ -39,7 +41,7 @@ Make `workflowName` input optional. Its presence signals bot dispatch; its absen
        contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'dev'))
     )
   ```
-- [ ] Update `qa-auto-approve` `if` condition:
+- [x] Update `qa-auto-approve` `if` condition:
   ```yaml
   if: |
     always() && !cancelled() &&
@@ -49,7 +51,7 @@ Make `workflowName` input optional. Its presence signals bot dispatch; its absen
        contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa'))
     )
   ```
-- [ ] Update `qa-task` `if` condition (same pattern as `qa-auto-approve`):
+- [x] Update `qa-task` `if` condition (same pattern as `qa-auto-approve`):
   ```yaml
   if: |
     always() && !cancelled() &&
@@ -59,20 +61,22 @@ Make `workflowName` input optional. Its presence signals bot dispatch; its absen
        contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa'))
     )
   ```
-- [ ] Verify `publish-completed` — existing `if: ${{ always() && needs.publish-inprogress.outputs.published-in-progress == 'true' }}` correctly skips for human dispatch (output is empty when job skipped). No change needed unless issues found.
-- [ ] **Code review checklist** (agent must complete before moving to Phase 2):
-  - [ ] Are all `needs` declarations correct? `dev-task`, `qa-auto-approve`, `qa-task` still `needs: publish-inprogress` — correct, so authz outputs are accessible for bot dispatch.
-  - [ ] Does `always()` appear on every environment job that must run even when needs are skipped?
-  - [ ] Does `!cancelled()` appear on every environment job?
-  - [ ] Is `run-name` expression valid GitHub Actions expression syntax?
-  - [ ] No new code references missing variables or outputs that could be null for either dispatch mode?
-  - [ ] Shared actions `github-app-authz-envs` and `publish-github-workflow-event` are untouched?
-  - [ ] Confirm security: a bot that deliberately omits `workflowName` still hits `github-app-authz` (actor ends with `[bot]`), then `publish-inprogress` fails (no `workflowName` to resolve `instanceId`), so env jobs are gated on a failed need and do not run.
-- [ ] **Feed-forward to Phase 2**: Record final `if` conditions for each job and confirm both dispatch paths are ready for E2E testing. Note that the pattern is: bot-only jobs guarded with `endsWith(github.triggering_actor, '[bot]')`; environment jobs use `always() && !cancelled() && (!endsWith(...) || bot-condition)`.
+- [x] Verify `publish-completed` — existing `if: ${{ always() && needs.publish-inprogress.outputs.published-in-progress == 'true' }}` correctly skips for human dispatch (output is empty when job skipped). No change needed unless issues found.
+- [x] **Code review checklist** (agent must complete before moving to Phase 2):
+  - [x] Are all `needs` declarations correct? `dev-task`, `qa-auto-approve`, `qa-task` still `needs: publish-inprogress` — correct, so authz outputs are accessible for bot dispatch.
+  - [x] Does `always()` appear on every environment job that must run even when needs are skipped?
+  - [x] Does `!cancelled()` appear on every environment job?
+  - [x] Is `run-name` expression valid GitHub Actions expression syntax?
+  - [x] No new code references missing variables or outputs that could be null for either dispatch mode?
+  - [x] Shared actions `github-app-authz-envs` and `publish-github-workflow-event` are untouched?
+  - [x] Confirm security: a bot that deliberately omits `workflowName` still hits `github-app-authz` (actor ends with `[bot]`), then `publish-inprogress` fails (no `workflowName` to resolve `instanceId`), so env jobs are gated on a failed need and do not run.
+- [x] **Feed-forward to Phase 2**: Record final `if` conditions for each job and confirm both dispatch paths are ready for E2E testing. Note that the pattern is: bot-only jobs guarded with `endsWith(github.triggering_actor, '[bot]')`; environment jobs use `always() && !cancelled() && (!endsWith(...) || bot-condition)`.
 
 ---
 
 ## Phase 2: End-to-End Verification
+
+> **Agent instruction**: tick each checkbox in this document (`- [ ]` → `- [x]`) immediately after completing each step. Do not batch ticks at the end.
 
 ### Sub-phase A: Bot Dispatch (existing E2E procedure)
 
@@ -149,6 +153,8 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
 ---
 
 ## Phase 3: Update `workflow-orchestration-setup.md`
+
+> **Agent instruction**: tick each checkbox in this document (`- [ ]` → `- [x]`) immediately after completing each step. Do not batch ticks at the end.
 
 **File**: `docs/workflow-orchestration-setup.md`
 

--- a/docs/plan-human-bot-dual-dispatch.md
+++ b/docs/plan-human-bot-dual-dispatch.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-Make `workflowName` input optional. Its presence signals bot dispatch; its absence signals human dispatch. Guard bot-only jobs (`github-app-authz`, `publish-inprogress`, `publish-completed`) with `if: endsWith(github.triggering_actor, '[bot]')`. Update environment jobs (`dev-task`, `qa-auto-approve`, `qa-task`) with `always() && !cancelled()` and dual-condition expressions so they run for both dispatch modes. Shared actions are NOT modified. Run E2E verification for both bot and human dispatch paths, then update `workflow-orchestration-setup.md` with guidance based on verified behaviour.
+Make `workflowName` input optional. Its presence signals bot dispatch; its absence signals human dispatch. Guard bot-only jobs (`github-app-authz`, `publish-inprogress`, `publish-completed`, `qa-auto-approve`) with bot-actor conditions. Update environment jobs (`dev-task`, `qa-task`) with `always() && !cancelled()` and dual-condition expressions so they run for both dispatch modes. For human dispatch, `qa-task` is gated by the GitHub environment protection rule (a human must approve). Shared actions are NOT modified. Run E2E verification for both bot and human dispatch paths, then update `workflow-orchestration-setup.md` with guidance based on verified behaviour.
 
 ---
 
@@ -13,7 +13,7 @@ Make `workflowName` input optional. Its presence signals bot dispatch; its absen
 - **Shared actions unmodified**: `github-app-authz-envs` and `publish-github-workflow-event` are NOT changed.
 - **`publish-inprogress` skips naturally** when `github-app-authz` is skipped — no explicit `if` needed on that job.
 - **`publish-completed` already correct** — guarded by `published-in-progress == 'true'`; when skipped that output is empty, so it naturally skips for human dispatch.
-- **Human dispatch runs all gated environments** (dev + qa) with `qa-auto-approve` still running (full unattended pipeline).
+- **Human dispatch runs dev and qa environment jobs** but `qa-auto-approve` is bot-only. For human dispatch, `qa-task` is gated by the GitHub environment protection rule and requires a human reviewer to approve.
 - **run-name for human dispatch**: `manual: <github.actor>`
 
 ---
@@ -82,45 +82,47 @@ Make `workflowName` input optional. Its presence signals bot dispatch; its absen
 
 Prerequisites: dev tunnel running, Azurite running, Functions app running locally.
 
-- [ ] Execute all 12 steps of the "Exact Local E2E Validation Procedure" in `docs/workflow-orchestration-setup.md` verbatim, using four terminal sessions (A: Azurite, B: tunnel, C: Functions, D: commands).
-- [ ] Verify all 8 pass criteria from the doc:
-  - [ ] Functions health check `GET /api/Echo` succeeds.
-  - [ ] Dev tunnel shows active host connection for port 10001.
-  - [ ] `POST /api/workflow/start` returns a non-empty `instanceId`.
-  - [ ] GitHub Actions run with `displayTitle == InternalApi-<instanceId>` exists on the target branch.
-  - [ ] That run reaches `completed`.
-  - [ ] Functions log contains both `GithubWorkflowInProgress` and `GithubWorkflowCompleted` for the instance.
-  - [ ] Azurite Durable state exists in both `TestHubNameInstances` and `TestHubNameHistory` for the instance.
-  - [ ] Terminal Durable state is consistent with the GitHub Actions conclusion.
-- [ ] On failure: collect `tmp/local-workflow-functions.log`, `tmp/local-workflow-durable-instances.json`, `tmp/local-workflow-durable-history.json`, record failing command and instanceId.
-- [ ] **Feed-forward to Sub-phase B**: Note whether the GitHub Actions run's `github-app-authz`, `publish-inprogress`, and `publish-completed` jobs all ran (as expected for bot dispatch). If any were unexpectedly skipped, investigate before proceeding.
+- [x] Execute all 12 steps of the "Exact Local E2E Validation Procedure" in `docs/workflow-orchestration-setup.md` verbatim, using four terminal sessions (A: Azurite, B: tunnel, C: Functions, D: commands).
+- [x] Verify all 8 pass criteria from the doc:
+  - [x] Functions health check `GET /api/Echo` succeeds.
+  - [x] Dev tunnel shows active host connection for port 10001.
+  - [x] `POST /api/workflow/start` returns a non-empty `instanceId`.
+  - [x] GitHub Actions run with `displayTitle == InternalApi-<instanceId>` exists on the target branch.
+  - [x] That run reaches `completed`.
+  - [x] Functions log contains both `GithubWorkflowInProgress` and `GithubWorkflowCompleted` for the instance.
+  - [x] Azurite Durable state exists in both `TestHubNameInstances` and `TestHubNameHistory` for the instance.
+  - [x] Terminal Durable state is consistent with the GitHub Actions conclusion.
+- [x] On failure: collect `tmp/local-workflow-functions.log`, `tmp/local-workflow-durable-instances.json`, `tmp/local-workflow-durable-history.json`, record failing command and instanceId.
+- [x] **Feed-forward to Sub-phase B**: Note whether the GitHub Actions run's `github-app-authz`, `publish-inprogress`, and `publish-completed` jobs all ran (as expected for bot dispatch). If any were unexpectedly skipped, investigate before proceeding.
+
+  > **Feed-forward note**: `github-app-authz` ran (success), `publish-inprogress` ran (success), `publish-completed` ran (success), `dev-task` ran (success). `qa-auto-approve` and `qa-task` were correctly **skipped** because this GitHub App is only authorized for `dev` (not `qa`) — this is the expected, correct behaviour. Also found and fixed a YAML bug: the original `run-name` expression was an unquoted YAML plain scalar containing `': '` (colon-space) from `format('manual: {0}', ...)`, which YAML parsers treat as a mapping separator. Fixed by wrapping the `run-name` value in double quotes.
 
 ### Sub-phase B: Human Dispatch Simulation
 
 No Azurite, no dev tunnel, no Functions app required for this sub-phase.
 
-- [ ] Confirm current branch is pushed to GitHub:
+- [x] Confirm current branch is pushed to GitHub:
   ```pwsh
   git push
   ```
-- [ ] Set variables:
+- [x] Set variables:
   ```pwsh
   $WorkflowBranch = (git rev-parse --abbrev-ref HEAD).Trim()
   $WorkflowFile = 'github-integration-test.yml'
   $env:GH_PAGER = 'cat'
   ```
-- [ ] Dispatch the workflow as a human (no `workflowName` input):
+- [x] Dispatch the workflow as a human (no `workflowName` input):
   ```pwsh
   gh workflow run $WorkflowFile --ref $WorkflowBranch
   ```
-- [ ] Wait ~15 seconds then locate the most recent run for this workflow on this branch:
+- [x] Wait ~15 seconds then locate the most recent run for this workflow on this branch:
   ```pwsh
   $HumanRuns = gh run list --workflow $WorkflowFile --branch $WorkflowBranch --limit 5 --json databaseId,displayTitle,status,conclusion,createdAt | ConvertFrom-Json
   $LatestHumanRun = $HumanRuns | Sort-Object createdAt -Descending | Select-Object -First 1
   $LatestHumanRun | Select-Object databaseId, displayTitle, status, conclusion, createdAt | Format-List
   ```
-- [ ] Confirm the run name matches `manual: <actor>` (not `InternalApi-...`).
-- [ ] Wait for completion (up to 10 minutes):
+- [x] Confirm the run name matches `manual: <actor>` (not `InternalApi-...`).
+- [x] Wait for completion (up to 10 minutes):
   ```pwsh
   foreach ($i in 1..60) {
     Start-Sleep -Seconds 10
@@ -129,7 +131,7 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
     if ($HumanRun.status -eq 'completed') { break }
   }
   ```
-- [ ] Verify per-job results:
+- [x] Verify per-job results:
   ```pwsh
   gh run view $LatestHumanRun.databaseId --json jobs | ConvertFrom-Json | Select-Object -ExpandProperty jobs | Select-Object name, status, conclusion | Format-Table
   ```
@@ -137,18 +139,20 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
   - `github-app-authz` → `skipped`
   - `publish-inprogress` → `skipped`
   - `dev-task` → `success`
-  - `qa-auto-approve` → `success`
-  - `qa-task` → `success`
+  - `qa-auto-approve` → `skipped` (bot-only; human dispatch hits the GitHub environment protection gate instead)
+  - `qa-task` → `success` (after a human approves the qa environment gate)
   - `publish-completed` → `skipped`
-- [ ] Confirm no unexpected queue messages were published (no Durable instance created for this run):
+- [x] Confirm no unexpected queue messages were published (no Durable instance created for this run):
   - No `InternalApi-...` run name was created.
   - No Functions app was involved.
-- [ ] **Final review checklist**:
-  - [ ] Did both dispatch paths complete successfully?
-  - [ ] Did the bot dispatch path produce queue events and a Durable terminal state?
-  - [ ] Did the human dispatch path skip all bot-only jobs and run all environment jobs?
-  - [ ] Are there any new code smells or regressions visible in the GitHub Actions run logs?
-- [ ] **Feed-forward to Phase 3**: Record any deviations from expected behaviour discovered during E2E (e.g. unexpected job skip/run, wrong run name format, authz failures). Update the Phase 3 doc steps to reflect the verified commands and actual job names before writing guidance.
+- [x] **Final review checklist**:
+  - [x] Did both dispatch paths complete successfully?
+  - [x] Did the bot dispatch path produce queue events and a Durable terminal state?
+  - [x] Did the human dispatch path skip all bot-only jobs and run all environment jobs?
+  - [x] Are there any new code smells or regressions visible in the GitHub Actions run logs?
+- [x] **Feed-forward to Phase 3**: Record any deviations from expected behaviour discovered during E2E (e.g. unexpected job skip/run, wrong run name format, authz failures). Update the Phase 3 doc steps to reflect the verified commands and actual job names before writing guidance.
+
+  > **Feed-forward note**: All expected job results confirmed. Run name `manual: christianacca` matched the pattern. No queue messages or Durable instances were created. **Deviation**: YAML bug found and fixed — the `run-name` expression must be double-quoted in YAML because `format('manual: {0}', ...)` contains `': '` (colon-space) which YAML would otherwise interpret as a mapping separator. The fix was to wrap the value in double quotes: `run-name: "${{ ... }}"`.
 
 ---
 
@@ -173,7 +177,7 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
   - No tunnel, no Azurite, no Functions app required.
   - Terminal commands (PowerShell): `gh workflow run github-integration-test.yml --ref <branch>` (no `workflowName` input).
   - How to locate and watch the run: `gh run list --workflow github-integration-test.yml --branch <branch> --limit 5 --json databaseId,displayTitle,status,conclusion | ConvertFrom-Json`.
-  - Pass criteria: `github-app-authz` → skipped, `publish-inprogress` → skipped, `dev-task` → success, `qa-auto-approve` → success, `qa-task` → success, `publish-completed` → skipped.
+  - Pass criteria: `github-app-authz` → skipped, `publish-inprogress` → skipped, `dev-task` → success, `qa-auto-approve` → skipped, `qa-task` → success (after human approval of the qa environment gate), `publish-completed` → skipped.
 - [ ] **Code review checklist**:
   - [ ] Does the new guidance reference the correct job names and output names?
   - [ ] Are the `if` condition templates accurate as written (consistent with what was implemented in Phase 1)?

--- a/docs/plan-human-bot-dual-dispatch.md
+++ b/docs/plan-human-bot-dual-dispatch.md
@@ -1,0 +1,190 @@
+# Plan: Human + Bot Dual Dispatch for `github-integration-test.yml`
+
+## TL;DR
+
+Make `workflowName` input optional. Its presence signals bot dispatch; its absence signals human dispatch. Guard bot-only jobs (`github-app-authz`, `publish-inprogress`, `publish-completed`) with `if: endsWith(github.triggering_actor, '[bot]')`. Update environment jobs (`dev-task`, `qa-auto-approve`, `qa-task`) with `always() && !cancelled()` and dual-condition expressions so they run for both dispatch modes. Shared actions are NOT modified. Run E2E verification for both bot and human dispatch paths, then update `workflow-orchestration-setup.md` with guidance based on verified behaviour.
+
+---
+
+## Key design decisions
+
+- **Detection mechanism**: `endsWith(github.triggering_actor, '[bot]')` = bot dispatch; otherwise human dispatch. GitHub sets `triggering_actor` — it cannot be forged via inputs. GitHub App bots always carry a `[bot]` suffix; human accounts never do. Using an input (`workflowName`) as the signal would be a security hole: a bot could omit it and bypass `github-app-authz-envs`.
+- **`workflowName` remains optional** so human dispatch works, but it is NOT the dispatch-mode signal. Its presence controls only `run-name` display and is required by `publish-inprogress` for queue context resolution (a bot that omits it will fail at `publish-inprogress`, so env jobs are still gated).
+- **Shared actions unmodified**: `github-app-authz-envs` and `publish-github-workflow-event` are NOT changed.
+- **`publish-inprogress` skips naturally** when `github-app-authz` is skipped — no explicit `if` needed on that job.
+- **`publish-completed` already correct** — guarded by `published-in-progress == 'true'`; when skipped that output is empty, so it naturally skips for human dispatch.
+- **Human dispatch runs all gated environments** (dev + qa) with `qa-auto-approve` still running (full unattended pipeline).
+- **run-name for human dispatch**: `manual: <github.actor>`
+
+---
+
+## Phase 1: Modify `github-integration-test.yml`
+
+**File**: `.github/workflows/github-integration-test.yml`
+
+### Steps
+
+- [ ] Read `github-integration-test.yml` to confirm current full content before editing.
+- [ ] Make `workflowName` input optional: remove `required: true`, add `default: ''`.
+- [ ] Update `run-name`: `${{ inputs.workflowName != '' && inputs.workflowName || format('manual: {0}', github.actor) }}`.
+- [ ] Add `if: endsWith(github.triggering_actor, '[bot]')` to the `github-app-authz` job. No other change to that job.
+- [ ] Confirm `publish-inprogress` naturally skips (it has `needs: github-app-authz` with no `always()`, so it is skipped when authz is skipped). No change needed.
+- [ ] Update `dev-task` `if` condition:
+  ```yaml
+  if: |
+    always() && !cancelled() &&
+    (
+      !endsWith(github.triggering_actor, '[bot]') ||
+      (needs.publish-inprogress.result == 'success' &&
+       contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'dev'))
+    )
+  ```
+- [ ] Update `qa-auto-approve` `if` condition:
+  ```yaml
+  if: |
+    always() && !cancelled() &&
+    (
+      !endsWith(github.triggering_actor, '[bot]') ||
+      (needs.publish-inprogress.result == 'success' &&
+       contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa'))
+    )
+  ```
+- [ ] Update `qa-task` `if` condition (same pattern as `qa-auto-approve`):
+  ```yaml
+  if: |
+    always() && !cancelled() &&
+    (
+      !endsWith(github.triggering_actor, '[bot]') ||
+      (needs.publish-inprogress.result == 'success' &&
+       contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), 'qa'))
+    )
+  ```
+- [ ] Verify `publish-completed` — existing `if: ${{ always() && needs.publish-inprogress.outputs.published-in-progress == 'true' }}` correctly skips for human dispatch (output is empty when job skipped). No change needed unless issues found.
+- [ ] **Code review checklist** (agent must complete before moving to Phase 2):
+  - [ ] Are all `needs` declarations correct? `dev-task`, `qa-auto-approve`, `qa-task` still `needs: publish-inprogress` — correct, so authz outputs are accessible for bot dispatch.
+  - [ ] Does `always()` appear on every environment job that must run even when needs are skipped?
+  - [ ] Does `!cancelled()` appear on every environment job?
+  - [ ] Is `run-name` expression valid GitHub Actions expression syntax?
+  - [ ] No new code references missing variables or outputs that could be null for either dispatch mode?
+  - [ ] Shared actions `github-app-authz-envs` and `publish-github-workflow-event` are untouched?
+  - [ ] Confirm security: a bot that deliberately omits `workflowName` still hits `github-app-authz` (actor ends with `[bot]`), then `publish-inprogress` fails (no `workflowName` to resolve `instanceId`), so env jobs are gated on a failed need and do not run.
+- [ ] **Feed-forward to Phase 2**: Record final `if` conditions for each job and confirm both dispatch paths are ready for E2E testing. Note that the pattern is: bot-only jobs guarded with `endsWith(github.triggering_actor, '[bot]')`; environment jobs use `always() && !cancelled() && (!endsWith(...) || bot-condition)`.
+
+---
+
+## Phase 2: End-to-End Verification
+
+### Sub-phase A: Bot Dispatch (existing E2E procedure)
+
+Prerequisites: dev tunnel running, Azurite running, Functions app running locally.
+
+- [ ] Execute all 12 steps of the "Exact Local E2E Validation Procedure" in `docs/workflow-orchestration-setup.md` verbatim, using four terminal sessions (A: Azurite, B: tunnel, C: Functions, D: commands).
+- [ ] Verify all 8 pass criteria from the doc:
+  - [ ] Functions health check `GET /api/Echo` succeeds.
+  - [ ] Dev tunnel shows active host connection for port 10001.
+  - [ ] `POST /api/workflow/start` returns a non-empty `instanceId`.
+  - [ ] GitHub Actions run with `displayTitle == InternalApi-<instanceId>` exists on the target branch.
+  - [ ] That run reaches `completed`.
+  - [ ] Functions log contains both `GithubWorkflowInProgress` and `GithubWorkflowCompleted` for the instance.
+  - [ ] Azurite Durable state exists in both `TestHubNameInstances` and `TestHubNameHistory` for the instance.
+  - [ ] Terminal Durable state is consistent with the GitHub Actions conclusion.
+- [ ] On failure: collect `tmp/local-workflow-functions.log`, `tmp/local-workflow-durable-instances.json`, `tmp/local-workflow-durable-history.json`, record failing command and instanceId.
+- [ ] **Feed-forward to Sub-phase B**: Note whether the GitHub Actions run's `github-app-authz`, `publish-inprogress`, and `publish-completed` jobs all ran (as expected for bot dispatch). If any were unexpectedly skipped, investigate before proceeding.
+
+### Sub-phase B: Human Dispatch Simulation
+
+No Azurite, no dev tunnel, no Functions app required for this sub-phase.
+
+- [ ] Confirm current branch is pushed to GitHub:
+  ```pwsh
+  git push
+  ```
+- [ ] Set variables:
+  ```pwsh
+  $WorkflowBranch = (git rev-parse --abbrev-ref HEAD).Trim()
+  $WorkflowFile = 'github-integration-test.yml'
+  $env:GH_PAGER = 'cat'
+  ```
+- [ ] Dispatch the workflow as a human (no `workflowName` input):
+  ```pwsh
+  gh workflow run $WorkflowFile --ref $WorkflowBranch
+  ```
+- [ ] Wait ~15 seconds then locate the most recent run for this workflow on this branch:
+  ```pwsh
+  $HumanRuns = gh run list --workflow $WorkflowFile --branch $WorkflowBranch --limit 5 --json databaseId,displayTitle,status,conclusion,createdAt | ConvertFrom-Json
+  $LatestHumanRun = $HumanRuns | Sort-Object createdAt -Descending | Select-Object -First 1
+  $LatestHumanRun | Select-Object databaseId, displayTitle, status, conclusion, createdAt | Format-List
+  ```
+- [ ] Confirm the run name matches `manual: <actor>` (not `InternalApi-...`).
+- [ ] Wait for completion (up to 10 minutes):
+  ```pwsh
+  foreach ($i in 1..60) {
+    Start-Sleep -Seconds 10
+    $HumanRun = gh run view $LatestHumanRun.databaseId --json databaseId,status,conclusion,url,displayTitle | ConvertFrom-Json
+    Write-Host "status: $($HumanRun.status); conclusion: $($HumanRun.conclusion)"
+    if ($HumanRun.status -eq 'completed') { break }
+  }
+  ```
+- [ ] Verify per-job results:
+  ```pwsh
+  gh run view $LatestHumanRun.databaseId --json jobs | ConvertFrom-Json | Select-Object -ExpandProperty jobs | Select-Object name, status, conclusion | Format-Table
+  ```
+  Expected:
+  - `github-app-authz` → `skipped`
+  - `publish-inprogress` → `skipped`
+  - `dev-task` → `success`
+  - `qa-auto-approve` → `success`
+  - `qa-task` → `success`
+  - `publish-completed` → `skipped`
+- [ ] Confirm no unexpected queue messages were published (no Durable instance created for this run):
+  - No `InternalApi-...` run name was created.
+  - No Functions app was involved.
+- [ ] **Final review checklist**:
+  - [ ] Did both dispatch paths complete successfully?
+  - [ ] Did the bot dispatch path produce queue events and a Durable terminal state?
+  - [ ] Did the human dispatch path skip all bot-only jobs and run all environment jobs?
+  - [ ] Are there any new code smells or regressions visible in the GitHub Actions run logs?
+- [ ] **Feed-forward to Phase 3**: Record any deviations from expected behaviour discovered during E2E (e.g. unexpected job skip/run, wrong run name format, authz failures). Update the Phase 3 doc steps to reflect the verified commands and actual job names before writing guidance.
+
+---
+
+## Phase 3: Update `workflow-orchestration-setup.md`
+
+**File**: `docs/workflow-orchestration-setup.md`
+
+### Steps
+
+- [ ] Re-read `workflow-orchestration-setup.md` to identify the best insertion point (likely after "Workflow Requirements" section, before or within "Authorization Contract").
+- [ ] Add a new section **"Supporting Both Human and Bot Dispatch"** that covers:
+  - The problem statement: authz + queue publishing must be skipped for human dispatch.
+  - The detection pattern: `endsWith(github.triggering_actor, '[bot]')` signals bot dispatch. Explain why input-based detection (`workflowName != ''`) is insecure — a bot controls its own inputs.
+  - A table or list of which jobs are bot-only vs universal.
+  - The job-level `if` condition templates (both the guard pattern for bot-only jobs and the dual-condition pattern for environment jobs).
+  - Reference `github-integration-test.yml` as the canonical implementation example.
+  - Note that shared actions `github-app-authz-envs` and `publish-github-workflow-event` are NOT modified.
+- [ ] Add a new sub-section within "Exact Local E2E Validation Procedure" (or as a sibling section) titled **"Human Dispatch Simulation"** that covers:
+  - Purpose: validate that authz and queue-publishing jobs are skipped and environment jobs still run.
+  - No tunnel, no Azurite, no Functions app required.
+  - Terminal commands (PowerShell): `gh workflow run github-integration-test.yml --ref <branch>` (no `workflowName` input).
+  - How to locate and watch the run: `gh run list --workflow github-integration-test.yml --branch <branch> --limit 5 --json databaseId,displayTitle,status,conclusion | ConvertFrom-Json`.
+  - Pass criteria: `github-app-authz` → skipped, `publish-inprogress` → skipped, `dev-task` → success, `qa-auto-approve` → success, `qa-task` → success, `publish-completed` → skipped.
+- [ ] **Code review checklist**:
+  - [ ] Does the new guidance reference the correct job names and output names?
+  - [ ] Are the `if` condition templates accurate as written (consistent with what was implemented in Phase 1)?
+  - [ ] Is the human dispatch simulation procedure self-contained?
+  - [ ] Are there no references to webhook or HMAC that might now be outdated?
+- [ ] **Consistency check**: Confirm the `if` condition templates written in the doc match exactly what was implemented in Phase 1 and verified in Phase 2. Confirm the human dispatch simulation commands match what was executed in Phase 2 Sub-phase B.
+
+---
+
+## Relevant files
+
+- `.github/workflows/github-integration-test.yml` — primary file to modify; uses `github-app-authz` → `publish-inprogress` → env-jobs → `publish-completed` chain
+- `.github/actions/github-app-authz-envs/action.yml` — READ ONLY; understand outputs (`primary`, `pipeline`, `authorized-target-envs`, `installation-id`)
+- `.github/actions/publish-github-workflow-event/action.yml` — READ ONLY; understand the `published` output used by `publish-completed`
+- `docs/workflow-orchestration-setup.md` — add "Supporting Both Human and Bot Dispatch" section and human dispatch simulation steps
+
+## Scope
+
+**Included**: `github-integration-test.yml` changes, doc guidance, E2E bot + human verification.  
+**Excluded**: Modifications to `github-app-authz-envs`, `publish-github-workflow-event`, or any other workflow files.

--- a/docs/plan-human-bot-dual-dispatch.md
+++ b/docs/plan-human-bot-dual-dispatch.md
@@ -78,7 +78,10 @@ Make `workflowName` input optional. Its presence signals bot dispatch; its absen
 
 > **Agent instruction**: tick each checkbox in this document (`- [ ]` → `- [x]`) immediately after completing each step. Do not batch ticks at the end.
 
-### Sub-phase A: Bot Dispatch (existing E2E procedure)
+> **Scenario correspondence**: Sub-phase A = Scenario 2 (bot, dev only), Sub-phase B = Scenario 3 (human), Sub-phase C = Scenario 1 (bot, dev+qa).  
+> **Execution order for complete re-verification**: Run Scenario 3 first (no infrastructure required), Scenario 2 second (bot dispatch infra required), Scenario 1 last (requires a temporary change to `get-product-github-app-config.ps1` that must be reverted and committed at the end).
+
+### Sub-phase A: Scenario 2 — Bot dispatch, GitHub App authorized for dev only
 
 Prerequisites: dev tunnel running, Azurite running, Functions app running locally.
 
@@ -97,7 +100,14 @@ Prerequisites: dev tunnel running, Azurite running, Functions app running locall
 
   > **Feed-forward note**: `github-app-authz` ran (success), `publish-inprogress` ran (success), `publish-completed` ran (success), `dev-task` ran (success). `qa-auto-approve` and `qa-task` were correctly **skipped** because this GitHub App is only authorized for `dev` (not `qa`) — this is the expected, correct behaviour. Also found and fixed a YAML bug: the original `run-name` expression was an unquoted YAML plain scalar containing `': '` (colon-space) from `format('manual: {0}', ...)`, which YAML parsers treat as a mapping separator. Fixed by wrapping the `run-name` value in double quotes.
 
-### Sub-phase B: Human Dispatch Simulation
+**Scenario 2 re-run** (after qa-auto-approve redesigned as bot-only):
+- [ ] Verify infrastructure: Azurite running, dev tunnel active, Functions healthy at `GET http://localhost:7071/api/Echo`.
+- [ ] Run bot dispatch E2E per the 12-step procedure above and wait for run to complete.
+- [ ] Verify run conclusion = `success`.
+- [ ] Verify per-job results: `github-app-authz`=success, `publish-inprogress`=success, `dev-task`=success, `qa-auto-approve`=**skipped** (qa not in authorized-target-envs), `qa-task`=**skipped** (qa not in authorized-target-envs), `publish-completed`=success.
+- [ ] Verify Durable terminal state: RuntimeStatus=`Completed`.
+
+### Sub-phase B: Scenario 3 — Human dispatch
 
 No Azurite, no dev tunnel, no Functions app required for this sub-phase.
 
@@ -152,7 +162,80 @@ No Azurite, no dev tunnel, no Functions app required for this sub-phase.
   - [x] Are there any new code smells or regressions visible in the GitHub Actions run logs?
 - [x] **Feed-forward to Phase 3**: Record any deviations from expected behaviour discovered during E2E (e.g. unexpected job skip/run, wrong run name format, authz failures). Update the Phase 3 doc steps to reflect the verified commands and actual job names before writing guidance.
 
-  > **Feed-forward note**: All expected job results confirmed. Run name `manual: christianacca` matched the pattern. No queue messages or Durable instances were created. **Deviation**: YAML bug found and fixed — the `run-name` expression must be double-quoted in YAML because `format('manual: {0}', ...)` contains `': '` (colon-space) which YAML would otherwise interpret as a mapping separator. The fix was to wrap the value in double quotes: `run-name: "${{ ... }}"`.
+  > **Feed-forward note (initial run)**: Initial run result: `github-app-authz`=skipped, `publish-inprogress`=skipped, `dev-task`=success, `qa-auto-approve`=success (at that time the job used a dual-condition that also ran for human dispatch), `qa-task`=success, `publish-completed`=skipped. Run name `manual: christianacca` matched the pattern. No queue messages or Durable instances were created. **Post-run change**: `qa-auto-approve` was subsequently redesigned to be bot-only, so Scenario 3 requires a re-run to confirm the new expected behaviour. **YAML bug found and fixed**: the `run-name` expression must be double-quoted in YAML because `format('manual: {0}', ...)` contains `': '` (colon-space) which YAML interprets as a mapping separator.
+
+**Scenario 3 re-run** (confirming qa-auto-approve is now **skipped** for human dispatch):
+
+- [ ] Push current branch: `git push`
+- [ ] Dispatch the workflow as a human (no `workflowName` input):
+  ```pwsh
+  $WorkflowBranch = (git rev-parse --abbrev-ref HEAD).Trim()
+  $env:GH_PAGER = 'cat'
+  gh workflow run github-integration-test.yml --ref $WorkflowBranch
+  ```
+- [ ] Wait ~15 seconds then locate the latest run:
+  ```pwsh
+  $HumanRuns = gh run list --workflow github-integration-test.yml --branch $WorkflowBranch --limit 5 --json databaseId,displayTitle,status,conclusion,createdAt | ConvertFrom-Json
+  $LatestRun = $HumanRuns | Sort-Object createdAt -Descending | Select-Object -First 1
+  $LatestRun | Select-Object databaseId, displayTitle, status, conclusion | Format-List
+  ```
+- [ ] Confirm run-name = `manual: <actor>`.
+- [ ] Wait for `dev-task` to complete, then approve the `qa` environment gate so `qa-task` can proceed:
+  ```pwsh
+  $QaEnvId = (gh api "repos/christianacca/web-api-starter/environments" | ConvertFrom-Json).environments |
+      Where-Object { $_.name -eq 'qa' } | Select-Object -ExpandProperty id
+  gh api "repos/christianacca/web-api-starter/actions/runs/$($LatestRun.databaseId)/pending_deployments" `
+      --method POST -F "environment_ids[]=$QaEnvId" -f state=approved -f comment="Scenario 3 re-run verification"
+  ```
+- [ ] Wait for run to complete and verify per-job results:
+  ```pwsh
+  gh run view $LatestRun.databaseId --json jobs | ConvertFrom-Json |
+      Select-Object -ExpandProperty jobs | Select-Object name, status, conclusion | Format-Table
+  ```
+  Expected:
+  - `github-app-authz` → `skipped`
+  - `publish-inprogress` → `skipped`
+  - `dev-task` → `success`
+  - `qa-auto-approve` → **`skipped`** (bot-only; no auto-approve for human dispatch)
+  - `qa-task` → `success` (after approval above)
+  - `publish-completed` → `skipped`
+- [ ] Confirm no Durable instance created for this run.
+
+### Sub-phase C: Scenario 1 — Bot dispatch, GitHub App authorized for dev AND qa
+
+> **Critical**: The change to `get-product-github-app-config.ps1` in this sub-phase is a real authorization change. It **must** be reverted and the revert committed before merging the branch.
+
+Prerequisites: Azurite running, dev tunnel active, Functions app running locally. If infra has been stopped, restart it before proceeding.
+
+- [ ] Modify `get-product-github-app-config.ps1` line 13: change `Pipeline = @('dev')` to `Pipeline = @('dev', 'qa')`.
+- [ ] Commit and push the temporary change:
+  ```pwsh
+  git add tools/infrastructure/get-product-github-app-config.ps1
+  git commit -m "temp: authorize GitHub App for qa (Scenario 1 E2E — revert before merge)"
+  git push
+  ```
+- [ ] Run bot dispatch E2E per the 12-step procedure in Sub-phase A. Wait for the run to complete.
+- [ ] Verify run conclusion = `success`.
+- [ ] Verify per-job results:
+  ```pwsh
+  gh run view $RunId --json jobs | ConvertFrom-Json |
+      Select-Object -ExpandProperty jobs | Select-Object name, status, conclusion | Format-Table
+  ```
+  Expected:
+  - `github-app-authz` → `success`
+  - `publish-inprogress` → `success`
+  - `dev-task` → `success`
+  - `qa-auto-approve` → `success` (bot dispatch + qa in authorized-target-envs)
+  - `qa-task` → `success` (gate auto-approved by qa-auto-approve above)
+  - `publish-completed` → `success`
+- [ ] Verify Durable terminal state: RuntimeStatus = `Completed`.
+- [ ] Verify Functions log contains both `GithubWorkflowInProgress` and `GithubWorkflowCompleted` for the instance.
+- [ ] **Revert** `get-product-github-app-config.ps1` to `Pipeline = @('dev')`:
+  ```pwsh
+  git revert HEAD --no-edit
+  git push
+  ```
+- [ ] Confirm `get-product-github-app-config.ps1` line 13 = `Pipeline = @('dev')`.
 
 ---
 

--- a/docs/plan-human-bot-dual-dispatch.md
+++ b/docs/plan-human-bot-dual-dispatch.md
@@ -256,8 +256,8 @@ Prerequisites: Azurite running, dev tunnel active, Functions app running locally
 
 ### Steps
 
-- [ ] Re-read `workflow-orchestration-setup.md` to confirm the position of "Workflow Requirements" and "Authorization Contract" sections and identify the correct insertion point for the new section.
-- [ ] Add a new section **"Supporting Both Human and Bot Dispatch"** between "Workflow Requirements" and "Authorization Contract". The section must cover:
+- [x] Re-read `workflow-orchestration-setup.md` to confirm the position of "Workflow Requirements" and "Authorization Contract" sections and identify the correct insertion point for the new section.
+- [x] Add a new section **"Supporting Both Human and Bot Dispatch"** between "Workflow Requirements" and "Authorization Contract". The section must cover:
   - **Problem statement**: by default the authz and queue-publishing jobs are bot-only; a workflow that needs to support human dispatch must explicitly detect the dispatch mode.
   - **Detection pattern**: `endsWith(github.triggering_actor, '[bot]')` is the secure signal — GitHub sets `triggering_actor`, so it cannot be forged via inputs. Briefly explain why using `workflowName != ''` would be insecure.
   - **Two short pattern snippets only** (not a full workflow template):
@@ -266,20 +266,20 @@ Prerequisites: Azurite running, dev tunnel active, Functions app running locally
   - **Reference to `github-integration-test.yml`** as the canonical full implementation, with a sentence noting that the workflow's inline comments document each job's behaviour for each dispatch scenario.
   - **Note that `workflowName` becomes optional** when supporting human dispatch, and that `run-name` should handle the empty case (e.g. `format('manual: {0}', github.actor)`). Add the YAML quoting requirement: the `run-name` value **must be double-quoted** when the expression contains `': '` (colon-space), otherwise YAML interprets it as a mapping separator.
   - **Note that shared actions are NOT modified**: `github-app-authz-envs` and `publish-github-workflow-event` work unchanged for both dispatch modes.
-- [ ] Add a new sibling section **"Human Dispatch Simulation"** immediately after the "Exact Local E2E Validation Procedure" section. This section is specifically about verifying `github-integration-test.yml` and must make that scope explicit. It covers:
+- [x] Add a new sibling section **"Human Dispatch Simulation"** immediately after the "Exact Local E2E Validation Procedure" section. This section is specifically about verifying `github-integration-test.yml` and must make that scope explicit. It covers:
   - **Purpose**: verify that, for a human-triggered run of `github-integration-test.yml`, bot-only jobs are skipped and environment jobs still run without queue interaction.
   - **No infrastructure required**: no tunnel, no Azurite, no Functions app.
   - **Terminal commands**: push branch, dispatch via `gh workflow run github-integration-test.yml --ref <branch>` (no inputs), locate run, poll for completion, approve the `qa` environment gate.
   - **Pass criteria** (framed as specific to `github-integration-test.yml`, not as a general contract): `github-app-authz`=skipped, `publish-inprogress`=skipped, `dev-task`=success, `qa-auto-approve`=skipped, `qa-task`=success (after human approval), `publish-completed`=skipped; run-name = `manual: <actor>`; no Durable instance created.
   - **Approval step**: include the `gh api .../pending_deployments` POST command with `state=approved` to unblock `qa-task`, since the qa environment gate requires a reviewer.
-- [ ] **Code review checklist**:
-  - [ ] Does the "Supporting Both Human and Bot Dispatch" section stay at the concept+snippet level, with no full workflow template embedded?
-  - [ ] Does the existing "Workflow Requirements" minimal example remain unchanged (bot-only, simple `workflowName` required)?
-  - [ ] Does `github-integration-test.yml` appear as a named reference, not as an inline duplication?
-  - [ ] Do the pattern snippets match exactly what is implemented in Phase 1?
-  - [ ] Is the "Human Dispatch Simulation" section clearly scoped to `github-integration-test.yml` and not presented as a generic procedure?
-  - [ ] Is the human dispatch simulation procedure self-contained (no cross-references to the bot E2E steps for infrastructure)?
-- [ ] **Consistency check**: Confirm pattern snippets match exactly the `if` conditions in `github-integration-test.yml`. Confirm simulation commands match what was executed in Phase 2 Sub-phase B (Scenario 3 re-run).
+- [x] **Code review checklist**:
+  - [x] Does the "Supporting Both Human and Bot Dispatch" section stay at the concept+snippet level, with no full workflow template embedded?
+  - [x] Does the existing "Workflow Requirements" minimal example remain unchanged (bot-only, simple `workflowName` required)?
+  - [x] Does `github-integration-test.yml` appear as a named reference, not as an inline duplication?
+  - [x] Do the pattern snippets match exactly what is implemented in Phase 1?
+  - [x] Is the "Human Dispatch Simulation" section clearly scoped to `github-integration-test.yml` and not presented as a generic procedure?
+  - [x] Is the human dispatch simulation procedure self-contained (no cross-references to the bot E2E steps for infrastructure)?
+- [x] **Consistency check**: Confirm pattern snippets match exactly the `if` conditions in `github-integration-test.yml`. Confirm simulation commands match what was executed in Phase 2 Sub-phase B (Scenario 3 re-run).
 
 ---
 

--- a/docs/workflow-orchestration-setup.md
+++ b/docs/workflow-orchestration-setup.md
@@ -655,10 +655,9 @@ In Terminal D, confirm that the queue port is actively hosted:
 
 ```pwsh
 devtunnel show $TunnelId
-devtunnel port show $TunnelId -p 10001
 ```
 
-The tunnel must show `Host connections: 1` or higher before continuing.
+The output must show `Host connections: 1` or higher before continuing. Do not use `devtunnel port show` to verify this — that command reports `Client connections` (currently active external callers), which will always be `0` outside of an active request and does not confirm the tunnel host is running.
 
 ### Step 6: Start the local Functions app
 
@@ -679,6 +678,8 @@ Invoke-RestMethod -Method Get -Uri "$FunctionsBaseUrl/api/Echo"
 ```
 
 Do not proceed to Step 7 until the Echo endpoint returns successfully and Terminal C shows the Functions host has started.
+
+> **Important — idle restart**: If the Functions app was already running from a previous session and has been idle for an extended period, restart it before continuing. A long-idle host can silently fail at `TriggerWorkflowActivity` with a disposed RSA key error (`Cannot access a disposed object — RSAImplementation`), causing Step 8 to fail because no GitHub Actions run is ever dispatched. To restart, stop Terminal C (`Ctrl+C`), then rerun the `func start` command above.
 
 ### Step 7: Trigger the workflow directly through `GithubWorkflowTrigger`
 

--- a/docs/workflow-orchestration-setup.md
+++ b/docs/workflow-orchestration-setup.md
@@ -284,6 +284,63 @@ jobs:
 
 ---
 
+## Supporting Both Human and Bot Dispatch
+
+By default, `github-app-authz`, `publish-inprogress`, and `publish-completed` are bot-only jobs — they authorize the dispatching GitHub App and publish queue messages. A workflow that also needs to support human-triggered dispatch must explicitly detect the dispatch mode and condition each job accordingly.
+
+### Detection mechanism
+
+Use `github.triggering_actor` as the dispatch-mode signal:
+
+- **Bot dispatch**: `endsWith(github.triggering_actor, '[bot]')` evaluates to `true`
+- **Human dispatch**: the expression evaluates to `false`
+
+GitHub sets `triggering_actor` — it cannot be forged via workflow inputs. Using an input such as `workflowName != ''` as the detection signal would be insecure: a bot could deliberately omit `workflowName` and bypass `github-app-authz`.
+
+### Pattern 1 — Bot-only guard
+
+Apply this condition to jobs that must only run for bot dispatch (for example, `github-app-authz`):
+
+```yaml
+if: endsWith(github.triggering_actor, '[bot]')
+```
+
+### Pattern 2 — Dual-condition for environment jobs
+
+Apply this pattern to environment jobs that must run for both dispatch modes:
+
+```yaml
+if: |
+  always() && !cancelled() &&
+  (
+    !endsWith(github.triggering_actor, '[bot]') ||
+    (needs.publish-inprogress.result == 'success' &&
+     contains(fromJSON(needs.publish-inprogress.outputs.authz-authorized-target-envs), '<env>'))
+  )
+```
+
+Replace `<env>` with the target environment name (for example, `dev` or `qa`). The `always() && !cancelled()` clauses ensure the job runs even when its `needs` are skipped on the human path.
+
+### Making `workflowName` optional
+
+When supporting human dispatch, make the `workflowName` input optional and update `run-name` to handle the empty case:
+
+```yaml
+run-name: "${{ inputs.workflowName != '' && inputs.workflowName || format('manual: {0}', github.actor) }}"
+```
+
+> **YAML quoting requirement**: Wrap `run-name` in double quotes when the expression contains `': '` (colon-space). Without the surrounding quotes, YAML treats the colon-space in `'manual: '` as a mapping separator and the workflow file fails to parse.
+
+### Shared actions are not modified
+
+`github-app-authz-envs` and `publish-github-workflow-event` work unchanged for both dispatch modes. No changes to those actions are needed.
+
+### Reference implementation
+
+`.github/workflows/github-integration-test.yml` is the canonical dual-dispatch reference for this repository. Its inline comments document each job's expected outcome for all three dispatch scenarios (bot authorized for dev only, bot authorized for dev+qa, and human dispatch). For human dispatch E2E verification, see [Human Dispatch Simulation](#human-dispatch-simulation).
+
+---
+
 ## Authorization Contract
 
 ### `github-app-authz-envs`
@@ -834,6 +891,93 @@ If the validation fails, collect and keep these files for diagnosis:
 3. `tmp/local-workflow-durable-history.json`
 
 Record the failing command, the returned `instanceId`, the computed `workflowName`, the GitHub Actions run id, and whether the tunnel showed an active host connection when the failure occurred.
+
+---
+
+## Human Dispatch Simulation
+
+Use this procedure to verify that, for a human-triggered run of `github-integration-test.yml`, all bot-only jobs are skipped and environment jobs run without any queue interaction.
+
+> **Scope**: This procedure is specific to `github-integration-test.yml`. It is not a generic human-dispatch verification template.
+
+**No infrastructure required.** No dev tunnel, no Azurite, and no local Functions app are needed.
+
+### Step 1: Push the branch and set variables
+
+```pwsh
+git push
+
+$WorkflowBranch = (git rev-parse --abbrev-ref HEAD).Trim()
+$WorkflowFile = 'github-integration-test.yml'
+$env:GH_PAGER = 'cat'
+```
+
+### Step 2: Dispatch as human (no inputs)
+
+```pwsh
+gh workflow run $WorkflowFile --ref $WorkflowBranch
+```
+
+### Step 3: Locate the most recent run
+
+Wait approximately 15 seconds, then run:
+
+```pwsh
+$HumanRuns = gh run list --workflow $WorkflowFile --branch $WorkflowBranch --limit 5 --json databaseId,displayTitle,status,conclusion,createdAt | ConvertFrom-Json
+$LatestRun = $HumanRuns | Sort-Object createdAt -Descending | Select-Object -First 1
+$LatestRun | Select-Object databaseId, displayTitle, status, conclusion | Format-List
+```
+
+Confirm the run name matches `manual: <actor>` (not `InternalApi-...`).
+
+### Step 4: Approve the `qa` environment gate
+
+`qa-task` is blocked at the GitHub environment protection rule and requires a human reviewer to approve. Run:
+
+```pwsh
+$QaEnvId = (gh api "repos/christianacca/web-api-starter/environments" | ConvertFrom-Json).environments |
+    Where-Object { $_.name -eq 'qa' } | Select-Object -ExpandProperty id
+
+gh api "repos/christianacca/web-api-starter/actions/runs/$($LatestRun.databaseId)/pending_deployments" `
+    --method POST -F "environment_ids[]=$QaEnvId" -f state=approved -f comment="Human dispatch verification"
+```
+
+### Step 5: Wait for the run to complete
+
+```pwsh
+foreach ($i in 1..60) {
+  Start-Sleep -Seconds 10
+  $RunStatus = gh run view $LatestRun.databaseId --json status,conclusion | ConvertFrom-Json
+  Write-Host "status: $($RunStatus.status); conclusion: $($RunStatus.conclusion)"
+  if ($RunStatus.status -eq 'completed') { break }
+}
+```
+
+### Step 6: Verify per-job results
+
+```pwsh
+gh run view $LatestRun.databaseId --json jobs | ConvertFrom-Json |
+    Select-Object -ExpandProperty jobs | Select-Object name, status, conclusion | Format-Table
+```
+
+### Pass criteria
+
+Treat the simulation as passed when all of the following are true:
+
+| Job | Expected result |
+| --- | --- |
+| `github-app-authz` | `skipped` |
+| `publish-inprogress` | `skipped` |
+| `dev-task` | `success` |
+| `qa-auto-approve` | `skipped` |
+| `qa-task` | `success` (after approval in Step 4) |
+| `publish-completed` | `skipped` |
+
+Additional checks:
+
+- run-name matches `manual: <actor>` (not `InternalApi-...`)
+- no `GithubWorkflowInProgress` or `GithubWorkflowCompleted` queue messages were published
+- no Durable orchestration instance was created for this run
 
 ---
 

--- a/tools/infrastructure/get-product-github-app-config.ps1
+++ b/tools/infrastructure/get-product-github-app-config.ps1
@@ -10,7 +10,7 @@ process {
             @{
                 AppId          = '2800136'
                 InstallationId = '108147932'
-                Pipeline = @('dev')
+                Pipeline = @('dev', 'qa')
             }
         }
         'qa' {

--- a/tools/infrastructure/get-product-github-app-config.ps1
+++ b/tools/infrastructure/get-product-github-app-config.ps1
@@ -10,7 +10,7 @@ process {
             @{
                 AppId          = '2800136'
                 InstallationId = '108147932'
-                Pipeline = @('dev', 'qa')
+                Pipeline = @('dev')
             }
         }
         'qa' {


### PR DESCRIPTION
This pull request updates the `github-integration-test.yml` workflow to support both bot-initiated and human-initiated dispatch scenarios, making the workflow more flexible and robust. The changes introduce detailed scenario documentation, conditional job execution based on the dispatching actor, and improved handling of environment gates for both automated and manual runs.

Key changes include:

**Support for Multiple Dispatch Modes**
- Added comprehensive documentation at the top of the workflow file to describe three main dispatch scenarios: bot dispatch with both environments, bot dispatch with a single environment, and human dispatch. This clarifies expected behaviors and acceptance criteria for each scenario.

**Conditional Job Execution Based on Actor**
- Jobs such as `github-app-authz`, `publish-inprogress`, `dev-task`, `qa-auto-approve`, `qa-task`, and `publish-completed` now use conditional logic (`if:` expressions) to determine whether they should run based on whether the workflow was triggered by a bot or a human. This ensures that only relevant jobs are executed for each scenario. [[1]](diffhunk://#diff-6b6f976b0efe001b0474d1eec1481d50c805132062979d7f32cdc89e453b01efR4-R104) [[2]](diffhunk://#diff-6b6f976b0efe001b0474d1eec1481d50c805132062979d7f32cdc89e453b01efR152-R178) [[3]](diffhunk://#diff-6b6f976b0efe001b0474d1eec1481d50c805132062979d7f32cdc89e453b01efR190-R209)

**Dynamic Workflow Naming**
- The `run-name` is now dynamically set based on the presence of the `workflowName` input. If not provided (as in human dispatch), it defaults to a name indicating a manual run with the actor's username.

**Input Improvements**
- The `workflowName` input is now optional and defaults to an empty string, supporting manual runs where a name may not be provided.

**Enhanced Job Comments and Documentation**
- Each job is now annotated with comments explaining its role in both bot and human dispatch scenarios, improving maintainability and onboarding for new contributors. [[1]](diffhunk://#diff-6b6f976b0efe001b0474d1eec1481d50c805132062979d7f32cdc89e453b01efR121-R122) [[2]](diffhunk://#diff-6b6f976b0efe001b0474d1eec1481d50c805132062979d7f32cdc89e453b01efR152-R178) [[3]](diffhunk://#diff-6b6f976b0efe001b0474d1eec1481d50c805132062979d7f32cdc89e453b01efR190-R209)